### PR TITLE
front-end post edit link bug fixed buddyforms_posttypes_default

### DIFF
--- a/includes/redirect.php
+++ b/includes/redirect.php
@@ -152,7 +152,7 @@ function bf_members_page_link_router_edit( $link, $id ) {
 	$buddyforms_posttypes_default = get_option( 'buddyforms_posttypes_default' );
 	$post_type                    = get_post_type( $id );
 
-	if ( isset( $buddyforms_posttypes_default[ $post_type ] ) ) {
+	if ( isset( $buddyforms_posttypes_default[ $post_type ] ) && $buddyforms_posttypes_default[ $post_type ] != 'none' ) {
 		$form_slug = $buddyforms_posttypes_default[ $post_type ];
 	}
 


### PR DESCRIPTION
When choosing 'none' for the standard form for a post type in the general settings the slug also became 'none' which made the front-end edit link not work. I changed it so the $form_slug doesn't get overwritten when the default post type is none.