### PR TITLE
Auto selecting "Send to Member" on the first notification.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -249,3 +249,36 @@ function buddyforms_check_send_message_to_member_conditions() {
 		$bf_notice->show_form_notices($messages);
 	}
 }
+
+add_action( 'buddyforms_before_update_form_options', 'buddyforms_enable_at_least_one_send_to_member_in_notifications', 10, 2 );
+function buddyforms_enable_at_least_one_send_to_member_in_notifications( $post_id, $buddyform ) {
+
+	$old_data = get_post_meta( $post_id, '_buddyforms_options', true );
+
+	// Send message to member is about to be enabled? 	
+	if ( isset( $buddyform['bp_profile_member_message'] ) && ! isset( $old_data['bp_profile_member_message'] ) ) {
+
+		$mail_to = array();
+		$notifications = $buddyform['mail_submissions'];
+
+		if ( ! is_array( $notifications ) && count( $notifications ) > 0 ) {
+			return;
+		}
+
+		foreach ($notifications as $index => $notification) {
+			$mail_to = array_merge( $mail_to, $notification['mail_to'] );
+		}
+
+		if ( ! in_array( 'member', $mail_to ) ) {
+
+			foreach ($notifications as &$notification ) {
+				$notification['mail_to'][] = 'member'; 
+				break;
+			}
+
+			$buddyform['mail_submissions'] = $notifications;
+		}
+	}
+
+	return $buddyform;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -251,7 +251,7 @@ function buddyforms_check_send_message_to_member_conditions() {
 }
 
 add_action( 'buddyforms_before_update_form_options', 'buddyforms_enable_at_least_one_send_to_member_in_notifications', 10, 2 );
-function buddyforms_enable_at_least_one_send_to_member_in_notifications( $post_id, $buddyform ) {
+function buddyforms_enable_at_least_one_send_to_member_in_notifications( $buddyform, $post_id ) {
 
 	$old_data = get_post_meta( $post_id, '_buddyforms_options', true );
 
@@ -262,10 +262,10 @@ function buddyforms_enable_at_least_one_send_to_member_in_notifications( $post_i
 		$notifications = $buddyform['mail_submissions'];
 
 		if ( ! is_array( $notifications ) && count( $notifications ) > 0 ) {
-			return;
+			return $buddyform;
 		}
 
-		foreach ($notifications as $index => $notification) {
+		foreach ($notifications as $notification) {
 			$mail_to = array_merge( $mail_to, $notification['mail_to'] );
 		}
 


### PR DESCRIPTION
Auto selecting "Send to Member" on the first notification after enabled the option "Send Message to Member".

Previously if you enabled the option Send Message to Member on the BF Member Metabox, always get this notice.

![image](https://user-images.githubusercontent.com/36063539/98888215-f081b680-246d-11eb-9fc9-a6e17eed2edc.png)

To avoid that now we check "Send to Member" on the first notification setting.

This feature depends on the filter **buddyforms_before_update_form_options** added to BuddyForms core.